### PR TITLE
fix: correct developer id and screenshot URL in metainfo

### DIFF
--- a/io.frappe.books.appdata.xml
+++ b/io.frappe.books.appdata.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>io.frappe.books</id>
-  
+
   <name>Books</name>
   <summary>Free Desktop book-keeping software for small businesses and freelancers</summary>
-  
+
   <metadata_license>FSFAP</metadata_license>
   <project_license>AGPL-3.0-only</project_license>
   <content_rating type="oars-1.1" />
@@ -13,19 +13,19 @@
     <control>keyboard</control>
     <control>touch</control>
   </supports>
-  
+
   <description>
     <p>
       Frappe Books is a desktop accounting app, one that has a modern UI. It&apos;s simple, well-designed, and free. Usually you have to give up one of them, and if not there&apos;s often a catch. Enter your credit card details. With Frappe Books there is no catch.
     </p>
   </description>
-  
+
   <launchable type="desktop-id">io.frappe.books.desktop</launchable>
 
 	<url type="homepage">https://frappe.io/books</url>
 	<url type="bugtracker">https://github.com/frappe/books/issues</url>
-	
-	<developer id="io.frappe.books">
+
+	<developer id="io.frappe">
 		<name>Frappe</name>
 	</developer>
 
@@ -82,7 +82,8 @@
 
 	<screenshots>
     <screenshot type="default">
-      <image>https://user-images.githubusercontent.com/29507195/207267857-4ae48890-3fb2-4046-80cf-3256b46c72a0.png</image>
+      <caption>Frappe Books desktop accounting application</caption>
+      <image>https://raw.githubusercontent.com/frappe/books/master/.github/frappe-books-preview.png</image>
     </screenshot>
   </screenshots>
 

--- a/io.frappe.books.appdata.xml
+++ b/io.frappe.books.appdata.xml
@@ -24,6 +24,7 @@
 
 	<url type="homepage">https://frappe.io/books</url>
 	<url type="bugtracker">https://github.com/frappe/books/issues</url>
+	<url type="vcs-browser">https://github.com/frappe/books</url>
 
 	<developer id="io.frappe">
 		<name>Frappe</name>


### PR DESCRIPTION
This is aimed at setting the groundwork for Flathub verification.

Related issue on Frappe Book's repo: https://github.com/frappe/books/issues/1144

## What

Two small metainfo fixes in `io.frappe.books.appdata.xml`:

1. **`<developer id>` corrected** — was `io.frappe.books` (the full app ID), should be `io.frappe` (the organisation/domain prefix). Per the AppStream spec and Flathub guidelines, this field identifies the publisher, not the app itself.

2. **Screenshot URL stabilised** — the previous URL pointed to `user-images.githubusercontent.com`, which hosts images uploaded to GitHub issues/PRs and can break if the source issue or repo changes. Replaced with a `raw.githubusercontent.com` URL that is tracked directly in the upstream `frappe/books` repository.

## Why

The wrong `developer id` is a correctness issue and may affect how Flathub resolves the publisher when the team goes to verify the app. The screenshot URL is a reliability fix — the old URL was already at risk of going stale.
