### PR TITLE
fix: correct version extraction and prevent duplicate appdata entries

### DIFF
--- a/.github/workflows/check-for-updates.yml
+++ b/.github/workflows/check-for-updates.yml
@@ -41,7 +41,7 @@ jobs:
             echo "has_update=false" >> "$GITHUB_OUTPUT"
             echo "Already up to date."
           else
-            version=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' io.frappe.books.yml | head -1)
+            version=$(grep -oP '(?<=tag: v)[0-9]+\.[0-9]+\.[0-9]+' io.frappe.books.yml)
             echo "has_update=true" >> "$GITHUB_OUTPUT"
             echo "version=$version" >> "$GITHUB_OUTPUT"
             echo "Update to v$version is ready."

--- a/update-manifest.sh
+++ b/update-manifest.sh
@@ -8,14 +8,14 @@ set -e
 
 api_response=$(curl -s -f https://api.github.com/repos/frappe/books/releases?per_page=1)
 
-upstream_version=$(echo  "$api_response"  | jq -r '.[0].name')
+upstream_version=$(echo "$api_response" | jq -r '.[0].tag_name' | sed 's/^v//')
 
 release_date=$(echo "$api_response" | jq -r '.[0].published_at' | cut -dT -f1)
 
 manifest_file='io.frappe.books.yml'
 appdata_file='io.frappe.books.appdata.xml'
 
-local_version=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' "$manifest_file" | head -1)
+local_version=$(grep -oP '(?<=tag: v)[0-9]+\.[0-9]+\.[0-9]+' "$manifest_file")
 
 if [[ "$local_version" == "$upstream_version" ]]; then
  echo "No updates found"
@@ -63,8 +63,11 @@ fi
 
 # Insert the new release entry at the top of the <releases> section
 echo "Updating $appdata_file..."
-tmp_appdata=$(mktemp)
-awk -v version="$upstream_version" -v date="$release_date" '
+if grep -q "version=\"$upstream_version\"" "$appdata_file"; then
+  echo "Release $upstream_version already present in $appdata_file, skipping."
+else
+  tmp_appdata=$(mktemp)
+  awk -v version="$upstream_version" -v date="$release_date" '
 /<releases>/ {
     print
     print "    <release version=\"" version "\" date=\"" date "\">"
@@ -74,8 +77,8 @@ awk -v version="$upstream_version" -v date="$release_date" '
 }
 { print }
 ' "$appdata_file" > "$tmp_appdata" && mv "$tmp_appdata" "$appdata_file"
-
-echo "Updated $appdata_file"
+  echo "Updated $appdata_file"
+fi
 echo ""
 echo "Done! Manifest updated to v$upstream_version."
 echo "Review the changes, then commit:"


### PR DESCRIPTION
## Fix automated update workflow

Resolves two bugs introduced in the first run of the auto-update workflow (see #26).

### Problems

**Wrong version in PR title / branch name**
Both `update-manifest.sh` and the workflow's post-run step extracted the
local and upstream versions with a generic semver regex
(`grep -oE '[0-9]+\.[0-9]+\.[0-9]+'  ... | head -1`).
Because `npm_config_nodedir` embeds the Electron Node headers version
(`22.3.27`) earlier in the YAML file than `tag: v0.36.0`, `head -1`
always returned `22.3.27`, poisoning every version comparison and every
PR title / branch name.

Additionally, `upstream_version` was read from `.[0].name` (the
free-text release title) instead of `.[0].tag_name` (the actual Git
tag), which is an unreliable source for a version string.

**Duplicate `<release>` entry in appdata.xml**
Because the version comparison above always evaluated as "not equal",
the script unconditionally ran the `awk` insert block on every
execution — even when the appdata file already contained the correct
entry — producing a duplicate `<release version="0.36.0" …>` block.

### Changes

| File | Change |
|------|--------|
| `update-manifest.sh` | Use `.[0].tag_name \| sed 's/^v//'` for upstream version; anchor local version extraction to `tag: v`; skip appdata insert if the version is already present |
| `.github/workflows/check-for-updates.yml` | Same anchor fix for the post-run version extraction used in PR title, branch name, and commit message |

### Testing

- The next scheduled (or manually triggered) run will now correctly
  detect that `0.36.0 == 0.36.0` and exit early with "No updates found"
  rather than opening another duplicate PR.
- When a genuine new release (e.g. `v0.37.0`) is published upstream,
  the workflow will open a PR titled `chore: update Frappe Books to
  v0.37.0` with a single, non-duplicate appdata entry.
